### PR TITLE
:recycle: Small refactor, cleaning up helper funcs

### DIFF
--- a/backend/users/utils/auth_utils.py
+++ b/backend/users/utils/auth_utils.py
@@ -1,0 +1,32 @@
+from django.middleware.csrf import get_token
+
+
+# NOTE: Helper function for setting cookies (consider moving into separate file/Class)
+def set_authentication_cookies(response, access_token, refresh_token, request):
+    response.set_cookie(
+        key='access_token',
+        value=access_token,
+        httponly=True,
+        samesite='None',
+        secure=True,
+        path='/',
+    )
+    response.set_cookie(
+        key='refresh_token',
+        value=refresh_token,
+        httponly=True,
+        samesite='None',
+        secure=True,
+        path='/',
+    )
+    # NOTE: Sets the csrftoken as cookie by default
+    get_token(request)
+    return response
+
+
+def remove_authenticated_cookies(response):
+    response.delete_cookie('access_token')
+    response.delete_cookie('refresh_token')
+    response.delete_cookie('csrftoken')
+    response.delete_cookie('sessionid')
+    return response

--- a/backend/users/utils/s3_utils.py
+++ b/backend/users/utils/s3_utils.py
@@ -1,0 +1,18 @@
+import logging
+import boto3
+
+logger = logging.getLogger(__name__)
+
+
+def grab_file_list():
+    try:
+        file_list = []
+        s3 = boto3.client('s3')
+        response = s3.list_objects_v2(Bucket='phlint-app-s3-test')
+        if (response):
+            for contents in response['Contents']:
+                file_list.append(contents["Key"])
+        return file_list
+    except Exception as e:
+        logger.error("S3 error: %s", str(e))
+        return []


### PR DESCRIPTION
This small refactor simply separates out the helper functions to the application's routes into a separate `utils/` directory. It also adds a simple Response type to the route functions' signatures.