### PR TITLE
:construction: 017_refactor_s3_logic

### DIFF
--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -17,4 +17,6 @@ urlpatterns = [
             get_gallery_test),
     path('api/email-registration/', email_registration_view),
     path('api/activate/', activate, name='activate'),
+    re_path('api/upload-gallery-test/' + r'social/(?P<backend>[^/]+)/$',
+            upload_gallery_test)
 ]

--- a/backend/users/utils/auth_utils.py
+++ b/backend/users/utils/auth_utils.py
@@ -11,12 +11,15 @@ from time import time
 from django.conf import settings
 from django.middleware.csrf import get_token
 
+from rest_framework.response import Response
+
 from Cryptodome.Cipher import AES
 from Cryptodome.Random import get_random_bytes
 
 
 # NOTE: Helper function for setting cookies (consider moving into separate file/Class)
-def set_authentication_cookies(response, access_token, refresh_token, request):
+def set_authentication_cookies(response, access_token, refresh_token,
+                               request) -> Response:
     response.set_cookie(
         key='access_token',
         value=access_token,
@@ -38,7 +41,7 @@ def set_authentication_cookies(response, access_token, refresh_token, request):
     return response
 
 
-def remove_authenticated_cookies(response):
+def remove_authenticated_cookies(response) -> Response:
     response.delete_cookie('access_token')
     response.delete_cookie('refresh_token')
     response.delete_cookie('csrftoken')
@@ -46,7 +49,7 @@ def remove_authenticated_cookies(response):
     return response
 
 
-def generate_sha256_hash(email):
+def generate_sha256_hash(email) -> str:
     secret_key = os.urandom(32)
     timestamp = str(int(time())).encode('utf-8')
     message = email.encode('utf-8') + timestamp
@@ -57,7 +60,7 @@ def generate_sha256_hash(email):
 
 # AES Encryption/Decryption Algorithms from boot.dev
 # https://blog.boot.dev/cryptography/aes-256-cipher-python-cryptography-examples/
-def encrypt(plain_text, password):
+def encrypt(plain_text, password) -> str:
     # generate a random salt
     salt = get_random_bytes(AES.block_size)
 
@@ -84,7 +87,7 @@ def encrypt(plain_text, password):
     return encrypted_data
 
 
-def decrypt(encrypted_data, password):
+def decrypt(encrypted_data, password) -> str:
     # split the string back into its components
     salt, cipher_text, nonce, tag = encrypted_data.split('::')
 

--- a/backend/users/utils/s3_utils.py
+++ b/backend/users/utils/s3_utils.py
@@ -47,13 +47,20 @@ def grab_file_list(bucket) -> List[str]:
         return []
 
 
-def upload_file(file_name, bucket, object_name=None) -> bool:
-    if object_name is None:
-        object_name = os.path.basename(file_name)
-
+def upload_file(file, bucket, object_name=None, gallery_name=None) -> bool:
     s3_client = boto3.client('s3')
+    if gallery_name is None:
+        gallery_name = 'default/'
     try:
-        s3_client.upload_file(file_name, bucket, object_name)
+        # NOTE: If object_name is not NONE, then get file
+        # from file-like object (direct upload)
+        if object_name is not None:
+            object_name = os.path.join(gallery_name, os.path.basename(file))
+            s3_client.upload_file(file, bucket, object_name)
+        # NOTE: Otherwise, get file from file system (hard drive)
+        else:
+            object_name = os.path.join(gallery_name, file.name)
+            s3_client.upload_fileobj(file, bucket, object_name)
     except Exception as e:
         logging.error(e)
         return False

--- a/backend/users/utils/s3_utils.py
+++ b/backend/users/utils/s3_utils.py
@@ -33,7 +33,6 @@ def delete_bucket(bucket) -> bool:
     return True
 
 
-# TODO: add bucket parameter/argument
 def grab_file_list(bucket) -> List[str]:
     try:
         file_list = []

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -15,3 +15,8 @@
 .gallery {
     padding-top: 3.5em;
 }
+
+.file-picker {
+    display: none;
+    color: transparent;
+}

--- a/frontend/src/config/urls.ts
+++ b/frontend/src/config/urls.ts
@@ -9,6 +9,8 @@ export default {
         'http://localhost:8000/api/authentication-test/social/google-oauth2/',
     BACKEND_GALLERY_ROUTE:
         'http://localhost:8000/api/get-gallery-test/social/google-oauth2/',
+    BACKEND_UPLOAD_IMAGE_ROUTE:
+        'http://localhost:8000/api/upload-gallery-test/social/google-oauth2/',
     BACKEND_EMAIL_REGISTRATION_ROUTE:
         'http://localhost:8000/api/email-registration/',
     BACKEND_ONBOARD_ROUTE: 'http://localhost:8000/api/activate/',


### PR DESCRIPTION
This PR refactors the s3 logic to no longer utilize s3 "folders"(AKA "directories") to establish user collections of albums, but rather uses individual s3 buckets to differentiate user's collections of albums/images.

It also establishes the initial logic for uploading new images to an album. Currently this is only able to upload to a single 'default' gallery.